### PR TITLE
Various fixes to dqt so that it can generate the qt .d files again

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,6 +1,6 @@
 {
     "name": "dqt",
-    "targetType": "none",
+    "targetType": "library",
     "targetPath": "lib",
     "description": "Qt bindings for D",
     "authors": ["w0rp"],

--- a/dub.json
+++ b/dub.json
@@ -8,15 +8,15 @@
     "license": "BSD 2-clause",
     "copyright": "Copyright © 2014, w0rp",
     "preGenerateCommands": [
-        "cd generator && dub build",
+        "cd generator && dub build -b release",
         "generator/bin/dqt_generator"
     ],
     "libs": [
         "smokeqtcore",
         "smokeqtgui"
     ],
-    "buildOptions": [
-        "ignoreDeprecations"
+    "buildRequirements": [
+        "silenceDeprecations"
     ],
     "dependencies": {
         "dsmoke": {

--- a/generator/dub.json
+++ b/generator/dub.json
@@ -7,9 +7,6 @@
         "smokeqtcore",
         "smokeqtgui"
     ],
-    "buildOptions" : [
-        "inline"
-    ],
     "dependencies": {
         "dsmoke": {
             "version": "~master",

--- a/generator/source/app.d
+++ b/generator/source/app.d
@@ -1,7 +1,7 @@
+import core.time;
 import std.algorithm;
 import std.string;
 import std.array;
-import std.datetime;
 import std.stdio;
 
 import smoke.smoke;
@@ -22,9 +22,7 @@ immutable(SmokeContainer) loadQtSmokeContainer() {
 void main() {
     writeln("Generating D source files...");
 
-    StopWatch stopWatch;
-
-    stopWatch.start();
+    immutable start = MonoTime.currTime();
 
     auto container = loadQtSmokeContainer();
 
@@ -187,7 +185,6 @@ void main() {
         CleanBuildDirectory.yes
     );
 
-    stopWatch.stop();
-
-    writefln("Generation done in %d milliseconds.", stopWatch.peek.msecs);
+    auto timeElapsed = MonoTime.currTime() - start;
+    writefln("Generation done in %d milliseconds.", timeElapsed.total!"msecs");
 }

--- a/source/nothing.d
+++ b/source/nothing.d
@@ -1,0 +1,3 @@
+// This is just here so that dub will let this project build with the
+// "library" targetType when the source files don't exist until after
+// the "preGenerateCommands" are run.


### PR DESCRIPTION
With these fixes, the qt .d files are generated again. However, they don't build - primarily due to issues with override, which could be entertaining to fix. I'm guessing that the stuff in the build that tells it to ignore deprecations was so that the generated files would build in spite of the override problems but that since that was done, override became required even with deprecations disabled. So, for this to work, a solution for applying override correctly is going to need to be found. I don't know much about smoke. So, I don't know how easy that will be, but I at least got this stuff to the point that the files are being generate again, even if they unfortunately won't build for the moment.